### PR TITLE
Reverting os.environ["PYRSCHED_SECRET"] for improving test reliability

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,3 +18,4 @@ class TestServer:
         # this secret is expected to be in the form 
         # 12345678-1234-5678-1234-567812345678 (32 hex digits with 4 hyphens)
         assert len(caplog.records[1].getMessage()) == 36
+        # os.environ["PYRSCHED_SECRET"] = "not-so-secret"


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_authkey_no_env` by reverting key "PYRSCHED_SECRET" in `os.environ`.

The test can fail in this way if key "PYRSCHED_SECRET" in `os.environ` is simply deleted:
```
    def test_authkey_no_env(self, caplog, scheduler_server):
>       del(os.environ["PYRSCHED_SECRET"])

tests/test_server.py:12: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
......
>           raise KeyError(key) from None
E           KeyError: 'PYRSCHED_SECRET'

